### PR TITLE
Bugfix/dev 13715

### DIFF
--- a/EMSMobileSDK/src/main/java/experian/mobilesdk/NotificationReceiver.java
+++ b/EMSMobileSDK/src/main/java/experian/mobilesdk/NotificationReceiver.java
@@ -68,6 +68,8 @@ public class NotificationReceiver extends BroadcastReceiver {
         String title = "";
         String body = "";
         String channelId = ctx.getString(R.string.default_notification_channel_id);
+        String channelName = ctx.getString(R.string.default_notification_channel_name);
+
 
         NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(ctx,channelId);
 
@@ -107,7 +109,7 @@ public class NotificationReceiver extends BroadcastReceiver {
         NotificationManager mNotifyMgr =  (NotificationManager) ctx.getSystemService(NOTIFICATION_SERVICE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O){
-            NotificationChannel channel = new NotificationChannel(channelId,title,NotificationManager.IMPORTANCE_DEFAULT);
+            NotificationChannel channel = new NotificationChannel(channelId,channelName,NotificationManager.IMPORTANCE_DEFAULT);
             channel.setDescription(body);
 
             mNotifyMgr.createNotificationChannel(channel);

--- a/EMSMobileSDK/src/main/res/values/strings.xml
+++ b/EMSMobileSDK/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">mobilesdk</string>
     <string name="default_notification_channel_id">fcm_default_channel</string>
+    <string name="default_notification_channel_name">EMS Channel</string>
 </resources>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -491,6 +491,10 @@ The EMS Mobile SDK displays basic notification information received from Firebas
 </receiver>
 ```
 
+### Override Notification Channel Name
+The EMS Mobile SDK uses **default_notification_channel_name** to create the notification channel name. By default, notification channel name is **EMS Channel**.  The app developer can override this by overriding  **default_notification_channel_name**  in **strings.xml**
+
+
 #### Receiver
 
 The following is the default behavior defined by the SDK in the NotificationReceiver.  


### PR DESCRIPTION
Upon checking the SDK, it seems that the JSON payload being sent does not have a title. As what was reported, there were blank push notifications being deployed. We believe that this is for Android 7 and below devices. As for Android 8 and above, crash occurs. So may we know the exact JSON payload being sent? In order to avoid this, make sure that in the JSON payload, title is present. Also, we suggest to add a SDK fix to prevent this from happening. Our suggestion is NOT to display the notification if there is no title and body. However, if either one is present, we will still display the notification. 